### PR TITLE
Refactor keyword arguments

### DIFF
--- a/src/BrowserMacros.jl
+++ b/src/BrowserMacros.jl
@@ -14,7 +14,7 @@ using Pkg.Operations: find_urls
 using HTTP: request
 
 # Generate macro `@wwwhich` the same way `@which` is generated:
-using InteractiveUtils: gen_call_with_extracted_types
+using InteractiveUtils: gen_call_with_extracted_types_and_kwargs
 
 # For `@issue` body:
 using Pkg: status

--- a/src/issue.jl
+++ b/src/issue.jl
@@ -38,7 +38,7 @@ function _issue_body()
     println(io, "<details>")
     println(io, "<summary>Version Info</summary>")
     println(io, "\n```")
-    versioninfo(io; verbose=true)
+    versioninfo(io; verbose=false)
     println(io, "```\n")
     println(io, "</details>\n")
     print(

--- a/src/search.jl
+++ b/src/search.jl
@@ -1,19 +1,36 @@
-function google(query::AbstractString; open_browser=true)
-    url = URI("https://www.google.com/search?q=$(escapeuri(query))")
-    open_browser && DefaultApplication.open(url)
-    return url
-end
-macro google(query, kwargs...)
-    return :(google($query; $(map(esc, kwargs)...)))
+const SEARCH_ENGINES = Dict(
+    :google => "https://www.google.com/search?q=", :ddg => "https://duckduckgo.com/?q="
+)
+for (fname, url) in SEARCH_ENGINES
+    @eval begin
+        function ($fname)(query::AbstractString; open_browser=true)
+            url = URI(($url) * escapeuri(query))
+            open_browser && DefaultApplication.open(url)
+            return url
+        end
+    end
 end
 
-function ddg(query::AbstractString; open_browser=true)
-    url = URI("https://duckduckgo.com/?q=$(escapeuri(query))")
-    open_browser && DefaultApplication.open(url)
-    return url
-end
-macro ddg(query, kwargs...)
-    return :(ddg($query; $(map(esc, kwargs)...)))
+for fname in keys(SEARCH_ENGINES)
+    @eval begin
+        macro ($fname)(ex0...)
+            # kwarg parsing adapted from InteractiveUtils' gen_call_with_extracted_types_and_kwargs
+            kwargs = Expr[]
+            query = ex0[end] # Mandatory argument
+            for i in 1:(length(ex0) - 1)
+                x = ex0[i]
+                if x isa Expr && x.head === :(=) # Keyword given of the form "foo=bar"
+                    if length(x.args) != 2
+                        return Expr(:call, :error, "Invalid keyword argument: $x")
+                    end
+                    push!(kwargs, Expr(:kw, esc(x.args[1]), esc(x.args[2])))
+                else
+                    return Expr(:call, :error, "More than one non-keyword argument passed.")
+                end
+            end
+            return :($(Expr(:quote, $(fname)))($query; $(kwargs...)))
+        end
+    end
 end
 
 """
@@ -45,7 +62,7 @@ Also usable as the function [`google`](@ref).
 julia> @google "Why is julialang called Julia?"
 ```
 ```julia-repl
-julia> url = @google "Why is julialang called Julia?" open_browser=false
+julia> url = @google open_browser=false "Why is julialang called Julia?"
 ```
 
 See also: [`@ddg`](@ref).
@@ -87,7 +104,7 @@ julia> @ddg "Why is julialang called Julia?"
 julia> @ddg "!gi Julia Logo"
 ```
 ```julia-repl
-julia> url = @ddg "!gi Julia Logo" open_browser=false
+julia> url = @ddg open_browser=false "!gi Julia Logo"
 ```
 
 See also: [`@google`](@ref).

--- a/src/wwwhich.jl
+++ b/src/wwwhich.jl
@@ -1,7 +1,4 @@
 function wwwhich(@nospecialize(f), @nospecialize(types); open_browser=true)
-    return wwwhich(f, types, open_browser)
-end
-function wwwhich(@nospecialize(f), @nospecialize(types), open_browser)
     method = which(f, types)
     url = method_url(method)
     if url_exists(url)
@@ -16,8 +13,8 @@ function wwwhich(@nospecialize(f), @nospecialize(types), open_browser)
     return nothing
 end
 
-macro wwwhich(ex0, kwargs...)
-    return gen_call_with_extracted_types(__module__, :wwwhich, ex0, map(esc, kwargs))
+macro wwwhich(ex0...)
+    return gen_call_with_extracted_types_and_kwargs(__module__, :wwwhich, ex0)
 end
 
 macro wwwhich(ex0::Symbol, kwargs...)
@@ -54,7 +51,7 @@ that points to the line of code returned by `@which`.
 julia> @wwwhich sqrt(5.0)
 ```
 ```julia-repl
-julia> url = @wwwhich sqrt(5.0) open_browser=false
+julia> url = @wwwhich open_browser=false sqrt(5.0)
 ```
 
 See also: [`@which`](@ref).

--- a/test/test_urls.jl
+++ b/test/test_urls.jl
@@ -5,23 +5,25 @@ using URIs: URI
 using InteractiveUtils: @which
 using DefaultApplication
 
+open_browser = 42 # For macro hygiene test at end of file
+
 url_google = URI(
     "https://www.google.com/search?q=123%21%40%23%24%25%5E%26%2A%28%29_%2BQWERT%7B%7D%7C"
 )
-url = @google "123!@#\$%^&*()_+QWERT{}|" open_browser = false
+url = @google open_browser = false "123!@#\$%^&*()_+QWERT{}|"
 @test url == url_google
 
 url_ddg = URI(
     "https://duckduckgo.com/?q=%EC%A4%84%EB%A6%AC%EC%95%84%2C%20%D8%AC%D9%88%D9%84%D9%8A%D8%A7",
 )
-url = @ddg "줄리아, جوليا" open_browser = false
+url = @ddg open_browser = false "줄리아, جوليا"
 @test url == url_ddg
 
 # Base
 m = @which sqrt(1.0)
 url1 = @inferred method_url(m)
 @test !isnothing(url1)
-url2 = @wwwhich sqrt(1.0) open_browser = false
+url2 = @wwwhich open_browser = false sqrt(1.0)
 @test url1 == url2
 
 # stdlib
@@ -34,3 +36,5 @@ url = wwwhich(DefaultApplication.open, (String,); open_browser=false)
 @test url == URI(
     "https://github.com/tpapp/DefaultApplication.jl/blob/v1.1.0/src/DefaultApplication.jl#L18",
 )
+
+@test open_browser == 42 # Test macro hygiene


### PR DESCRIPTION
This PR
* generalizes macros to support multiple keyword arguments 
* fixes macro hygiene
* avoids code duplication in search engines

Breaking changes:
* keyword arguments now have to be passed ahead of the expression / search query, e.g.:
  `url = @wwwhich open_browser=false sqrt(5.0)` 